### PR TITLE
Allow @Overwrite mixins to have their private status upgraded

### DIFF
--- a/src/main/resources/mixins.fluidlogged_api.json
+++ b/src/main/resources/mixins.fluidlogged_api.json
@@ -1,4 +1,7 @@
 {
   "compatibilityLevel": "JAVA_8",
-  "minVersion": "0.7"
+  "minVersion": "0.7",
+  "overwrites": {
+    "conformVisibility": true
+  }
 }


### PR DESCRIPTION
This fixes conflict with other mods' access transformers.
