### PR TITLE
Expose a set of APIs instead of the fluid state map itself

### DIFF
--- a/src/main/java/git/jbredwards/fluidlogged_api/api/util/FluidState.java
+++ b/src/main/java/git/jbredwards/fluidlogged_api/api/util/FluidState.java
@@ -78,7 +78,7 @@ public class FluidState extends Pair<Fluid, IBlockState>
     @Nonnull
     public static FluidState getFromProvider(@Nullable ICapabilityProvider p, @Nonnull BlockPos pos) {
         final @Nullable IFluidStateCapability cap = IFluidStateCapability.get(p);
-        return cap == null ? EMPTY : cap.getFluidStates().getOrDefault(pos.toLong(), EMPTY);
+        return cap == null ? EMPTY : cap.getFluidState(pos.toLong(), EMPTY);
     }
 
     //creates a new FluidState from the serialized one

--- a/src/main/java/git/jbredwards/fluidlogged_api/mod/common/EventHandler.java
+++ b/src/main/java/git/jbredwards/fluidlogged_api/mod/common/EventHandler.java
@@ -64,7 +64,7 @@ public final class EventHandler
     @SubscribeEvent
     public static void sendToPlayer(@Nonnull ChunkWatchEvent.Watch event) {
         final @Nullable IFluidStateCapability cap = IFluidStateCapability.get(event.getChunkInstance());
-        if(cap != null) Main.wrapper.sendTo(new SyncFluidStatesMessage(event.getChunk(), cap.getFluidStates()), event.getPlayer());
+        if(cap != null) Main.wrapper.sendTo(new SyncFluidStatesMessage(event.getChunk(), cap), event.getPlayer());
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
This allows locks to be added internally and removes implementation details from the API surface.

Fixes #105.