### PR TITLE
Fix referencing of removed Nothirium class

### DIFF
--- a/src/main/java/git/jbredwards/fluidlogged_api/mod/asm/ASMHandler.java
+++ b/src/main/java/git/jbredwards/fluidlogged_api/mod/asm/ASMHandler.java
@@ -56,7 +56,7 @@ public final class ASMHandler implements BasicLoadingPlugin
             plugins.put("io.github.opencubicchunks.cubicchunks.core.asm.mixin.core.client.MixinChunkCache_HeightLimits", new PluginCubicChunks()); //fix mixin annotation to target fluidlogged api transform
             plugins.put("me.jellysquid.mods.phosphor.mod.world.lighting.LightingEngine", new PluginHesperus()); //phosphor takes FluidStates into account when computing light
             plugins.put("me.jellysquid.mods.phosphor.mod.world.lighting.LightingHooks", new PluginHesperus()); //phosphor takes FluidStates into account when computing light
-            plugins.put("meldexun.nothirium.mc.renderer.chunk.RenderChunk$ChunkCache", new PluginNothirium()); //better nothirium compat
+            plugins.put("meldexun.nothirium.mc.renderer.chunk.SectionRenderCache", new PluginNothirium()); //better nothirium compat
             plugins.put("mods.railcraft.common.fluids.CustomContainerHandler", new PluginRailcraft()); //fix railcraft uncraftable potion bug when collecting water bottles (issue#148)
             plugins.put("mrtjp.projectred.core.TFaceConnectable$class", new PluginProjectRed()); //allow wires to connect through fluids
             plugins.put("net.optifine.override.ChunkCacheOF", new PluginOptifine()); //better optifine compat

--- a/src/main/java/git/jbredwards/fluidlogged_api/mod/asm/plugins/modded/PluginNothirium.java
+++ b/src/main/java/git/jbredwards/fluidlogged_api/mod/asm/plugins/modded/PluginNothirium.java
@@ -65,7 +65,7 @@ public final class PluginNothirium implements IASMPlugin
         addMethod(classNode, "getChunkFromBlockCoords", "(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/world/chunk/Chunk;", null, null, generator -> {
             generator.visitVarInsn(ALOAD, 0);
             generator.visitVarInsn(ALOAD, 1);
-            generator.visitMethodInsn(INVOKEVIRTUAL, "meldexun/nothirium/mc/renderer/chunk/RenderChunk$ChunkCache", "getChunk", "(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/world/chunk/Chunk;", false);
+            generator.visitMethodInsn(INVOKEVIRTUAL, "meldexun/nothirium/mc/renderer/chunk/SectionRenderCache", "getChunk", "(Lnet/minecraft/util/math/BlockPos;)Lnet/minecraft/world/chunk/Chunk;", false);
         });
 
         return true;


### PR DESCRIPTION
Nothirium renamed/moved the class `meldexun.nothirium.mc.renderer.chunk.RenderChunk$ChunkCache` to `meldexun.nothirium.mc.renderer.chunk.SectionRenderCache`. This PR changes the references in FluidloggedAPI to the new class path and name.